### PR TITLE
Fix GitHub Pages build failure by enabling Pages in workflow

### DIFF
--- a/.github/workflows/hugo.yml
+++ b/.github/workflows/hugo.yml
@@ -40,6 +40,8 @@ jobs:
       - name: Setup Pages
         id: pages
         uses: actions/configure-pages@v4
+        with:
+          enablement: true
       
       - name: Build with Hugo
         env:


### PR DESCRIPTION
Add enablement: true parameter to actions/configure-pages@v4 to automatically enable GitHub Pages for the repository when the workflow runs.