### PR TITLE
Grant contents: write permission to enable Pages creation

### DIFF
--- a/.github/workflows/hugo.yml
+++ b/.github/workflows/hugo.yml
@@ -7,7 +7,7 @@ on:
   workflow_dispatch:
 
 permissions:
-  contents: read
+  contents: write
   pages: write
   id-token: write
 


### PR DESCRIPTION
The configure-pages action with enablement: true requires write access to repository contents to create the GitHub Pages site.