### PR TITLE
Add debugging output to Hugo build workflow

### DIFF
--- a/.github/workflows/hugo.yml
+++ b/.github/workflows/hugo.yml
@@ -51,8 +51,16 @@ jobs:
           hugo \
             --gc \
             --minify \
-            --baseURL "${{ steps.pages.outputs.base_url }}/"
-      
+            --baseURL "${{ steps.pages.outputs.base_url }}/" \
+            --verbose
+
+      - name: List build output
+        run: |
+          echo "Contents of public directory:"
+          ls -la public/
+          echo "First level files:"
+          find public -maxdepth 2 -type f
+
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v3
         with:


### PR DESCRIPTION
Add verbose flag to Hugo build and list generated files to help diagnose why the README is being shown instead of the Hugo site.