### PR TITLE
Update homepage content for Dutch and English

### DIFF
--- a/content/en/_index.md
+++ b/content/en/_index.md
@@ -2,14 +2,14 @@
 title: "Pitrian"
 ---
 
-## Belgian Full-Stack Software Consultancy
+## I build software.
 
-Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.
+From problem to working product. I don't just write code, I think through the problem, design the solution, and build it. Complex business logic, messy requirements, tight integrations: that's where I do my best work.
 
-Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
+Previously built: Fiscalo and TenderWolf.
 
-### What We Do
+**Based in Belgium.**
 
-Sed ut perspiciatis unde omnis iste natus error sit voluptatem accusantium doloremque laudantium, totam rem aperiam, eaque ipsa quae ab illo inventore veritatis et quasi architecto beatae vitae dicta sunt explicabo.
+**Contact:** hello@pitrian.be
 
-Nemo enim ipsam voluptatem quia voluptas sit aspernatur aut odit aut fugit, sed quia consequuntur magni dolores eos qui ratione voluptatem sequi nesciunt.
+**Currently unavailable for new projects.**

--- a/content/nl/_index.md
+++ b/content/nl/_index.md
@@ -2,14 +2,14 @@
 title: "Pitrian"
 ---
 
-## Belgisch Full-Stack Software Consultancy
+## Ik bouw software.
 
-Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.
+Van probleem tot werkend product. Ik schrijf niet alleen code, ik denk het probleem door, ontwerp de oplossing, en bouw het. Complexe bedrijfslogica, rommelige requirements, strakke integraties: daar doe ik mijn beste werk.
 
-Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
+Eerder gebouwd: Fiscalo en TenderWolf.
 
-### Wat We Doen
+**Gevestigd in België.**
 
-Sed ut perspiciatis unde omnis iste natus error sit voluptatem accusantium doloremque laudantium, totam rem aperiam, eaque ipsa quae ab illo inventore veritatis et quasi architecto beatae vitae dicta sunt explicabo.
+**Contact:** hello@pitrian.be
 
-Nemo enim ipsam voluptatem quia voluptas sit aspernatur aut odit aut fugit, sed quia consequuntur magni dolores eos qui ratione voluptatem sequi nesciunt.
+**Momenteel niet beschikbaar voor nieuwe projecten.**


### PR DESCRIPTION
Replace placeholder Lorem ipsum content with actual copy that reflects Pitrian's work. The new content is more direct and personal, highlighting problem-solving approach and past work (Fiscalo, TenderWolf). Removed "What We Do" sections in favor of minimal, focused homepage.