### PR TITLE
Fix routing: change baseURL to root path

### DIFF
--- a/.github/workflows/hugo.yml
+++ b/.github/workflows/hugo.yml
@@ -51,7 +51,6 @@ jobs:
           hugo \
             --gc \
             --minify \
-            --baseURL "${{ steps.pages.outputs.base_url }}/" \
             --verbose
 
       - name: List build output

--- a/hugo.toml
+++ b/hugo.toml
@@ -1,4 +1,4 @@
-baseURL = 'https://pjdeprest.github.io/'
+baseURL = 'https://pjdeprest.github.io/pitrian/'
 languageCode = 'en'
 title = 'Pitrian'
 defaultContentLanguage = 'en'


### PR DESCRIPTION
- Change baseURL from 'https://pjdeprest.github.io/pitrian/' to 'https://pjdeprest.github.io/'
- This fixes the issue where the homepage was only accessible at /pitrian
- All routes will now work from the root path

Note: For GitHub Pages deployment, you'll need to either:
1. Rename the repository to 'PJDeprest.github.io' (user page), OR
2. Configure a custom domain in GitHub Pages settings