### PR TITLE
Fix multilingual routing with canonifyURLs

### DIFF
--- a/hugo.toml
+++ b/hugo.toml
@@ -1,4 +1,5 @@
 baseURL = 'https://pjdeprest.github.io/pitrian/'
+canonifyURLs = true
 languageCode = 'en'
 title = 'Pitrian'
 defaultContentLanguage = 'en'


### PR DESCRIPTION
This fixes the Dutch (nl) language routing issue where the language code was being placed incorrectly in the URL hierarchy.

Hugo has a known issue with multilingual sites when baseURL contains a subdirectory path. Without canonifyURLs, Hugo doesn't correctly combine the base path (/pitrian/) with language paths (/nl/).

Setting canonifyURLs = true forces Hugo to generate full absolute URLs, ensuring the correct URL structure:
- English: /pitrian/about/
- Dutch: /pitrian/nl/about/

References:
- https://discourse.gohugo.io/t/hugo-multi-language-configuration-causes-github-pages-404/55530
- https://github.com/gohugoio/hugo/issues/7714