### PR TITLE
Fix favicon to skew right and increase size

### DIFF
--- a/static/favicon.svg
+++ b/static/favicon.svg
@@ -1,3 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
-  <path d="M 20 30 L 70 30 L 80 70 L 30 70 Z" fill="#1a3d2e"/>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
+  <!-- Abstract parallelogram skewing right to match logo -->
+  <rect x="8" y="16" width="48" height="32" fill="#1a3d2e" transform="skewX(-10)"/>
 </svg>


### PR DESCRIPTION
- Changed favicon to skew right (skewX(-10)) to match logo direction
- Increased size from 100x100 to 64x64 viewBox with larger rectangle
- Maintains same #1a3d2e brand color