### PR TITLE
Adjust favicon parallelogram positioning with horizontal translation

### DIFF
--- a/static/favicon.svg
+++ b/static/favicon.svg
@@ -1,4 +1,4 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
   <!-- Abstract parallelogram skewing right to match logo -->
-  <rect x="8" y="16" width="48" height="32" fill="#1a3d2e" transform="skewX(-10)"/>
+  <rect x="8" y="16" width="48" height="32" fill="#1a3d2e" transform="translate(5.64, 0) skewX(-10)"/>
 </svg>


### PR DESCRIPTION
## Summary
Updated the favicon SVG to apply a horizontal translation to the skewed parallelogram shape, improving its visual alignment and positioning within the viewBox.

## Changes
- Added `translate(5.64, 0)` transform to the favicon rectangle element
- The translation shifts the parallelogram 5.64 units to the right before applying the existing skew transformation
- This adjustment refines the visual centering and positioning of the abstract parallelogram shape in the favicon

## Implementation Details
The transform chain now reads: `translate(5.64, 0) skewX(-10)`, which applies the translation first, then the skew. This ensures the parallelogram is properly positioned to match the intended logo design.

https://claude.ai/code/session_01JK3YA8TAS7hxuF3k7nE61P